### PR TITLE
Fix: missing required `apiKey`

### DIFF
--- a/client-sdks/usage-for-agents.mdx
+++ b/client-sdks/usage-for-agents.mdx
@@ -88,7 +88,7 @@ The assistant will know to use:
 ```typescript lines
 import { OpenRouter } from '@openrouter/sdk';
 
-const client = new OpenRouter();
+const client = new OpenRouter({ apiKey: process.env.OPENROUTER_API_KEY });
 
 const completion = await client.chat.send({
   model: 'anthropic/claude-sonnet-4',


### PR DESCRIPTION
The code example uses `new OpenRouter()` without passing the `apiKey` parameter.  
According to the SDK documentation and all other examples, the API key is mandatory.