### PR TITLE
Fix: Correct OpenRouter SDK import

### DIFF
--- a/client-sdks/typescript/overview.mdx
+++ b/client-sdks/typescript/overview.mdx
@@ -34,7 +34,7 @@ The OpenRouter TypeScript SDK is a type-safe toolkit for building AI application
 Integrating AI models into applications involves handling different provider APIs, managing model-specific requirements, and avoiding common implementation mistakes. The OpenRouter SDK standardizes these integrations and protects you from footguns.
 
 ```typescript lines
-import OpenRouter from '@openrouter/sdk';
+import { OpenRouter } from '@openrouter/sdk';
 
 const client = new OpenRouter({
   apiKey: process.env.OPENROUTER_API_KEY


### PR DESCRIPTION
Fixed import syntax in overview.mdx where default import (`import OpenRouter from '@openrouter/sdk'`) was used instead of named import (`import { OpenRouter } from '@openrouter/sdk'`), which is used consistently across all other documentation files (`quickstart.mdx`, `app-attribution.mdx`) and the official SDK documentation.