### PR TITLE
docs: fix mangled models link in video-generation guide

### DIFF
--- a/guides/overview/multimodal/video-generation.mdx
+++ b/guides/overview/multimodal/video-generation.mdx
@@ -21,7 +21,7 @@ import {
 } from '/snippets/exports/constants.mdx';
 import OpenRouterVideoSkill from "/snippets/openrouter-video-skill.mdx";
 
-OpenRouter supports video generation from text prompts (and optional reference images) via a dedicated asynchronous API. You can find the supported models, their capabilities, and pricing by filtering our [model list by video output](https://openrouter.ai/docs/guides/overview/models?output_modalities=video).
+OpenRouter supports video generation from text prompts (and optional reference images) via a dedicated asynchronous API. You can find the supported models, their capabilities, and pricing by filtering our [model list by video output](https://openrouter.ai/models?output_modalities=video).
 
 <Tip>
   Adding video generation to an app? The


### PR DESCRIPTION
## What

The video-generation guide's "model list by video output" link pointed at a docs path instead of the website model catalog:

```diff
-[model list by video output](https://openrouter.ai/docs/guides/overview/models?output_modalities=video)
+[model list by video output](https://openrouter.ai/models?output_modalities=video)
```

## Why

The Fern→Mintlify migration rewrote several website/API URLs into docs paths. It also mangled the curl blocks in this file and in `tts.mdx`/`stt.mdx` (some rewritten twice, e.g. `/api/v1/docs/guides/overview/docs/guides/overview/models`). Later sync PRs repaired all the **curl** blocks, but this one **prose** link slipped through — the fixups were curl-focused, and Mintlify's broken-link checker only validates internal relative links, so an external `openrouter.ai/docs/...` URL was never flagged.

Both URLs return HTTP 200, so nothing surfaced it as broken. The difference is where they land: the docs path resolves to the guide page and silently ignores `?output_modalities=video`, while `openrouter.ai/models?output_modalities=video` is the interactive catalog that honors the filter. This restores the intended behavior and matches how `image-generation.mdx` writes the equivalent link.

## Verification

- `mint broken-links` — this file is not among the flagged files.
- `curl "https://openrouter.ai/api/v1/models?output_modalities=video"` → `200`, 16 models.
- Confirmed the repo has zero remaining `api/v1/docs/guides`, doubled-prefix, or query-bearing docs URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)