### PR TITLE
docs: fix code block border-radius

### DIFF
--- a/style.css
+++ b/style.css
@@ -61,8 +61,15 @@ nav[aria-label="Pages"] a[aria-current="page"] {
   border-radius: 8px;
 }
 
-/* Cards and code blocks */
-[data-component-part="code-block-root"] {
+/* Standalone code blocks: round the outer bordered wrapper AND its inner
+ * background layer together, so the radii match at the corners.
+ * Code groups (.code-group with tabs) are untouched — their inner roots
+ * get rounded-xt!important from Mintlify and manage their own radii. */
+.code-block {
+  border-radius: 8px;
+}
+
+.code-block [data-component-part="code-block-root"] {
   border-radius: 8px;
 }
 


### PR DESCRIPTION
<table>
<thead>
<tr>
<th width="50%">Before</th>
<th width="50%">After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="1234" height="204" alt="CleanShot 2026-07-15 at 12  25 53@2x" src="https://github.com/user-attachments/assets/4c8d5cbf-f7ad-4906-9d7f-868cf19a5bdb" />

</td>
<td>
<img width="1234" height="204" alt="CleanShot 2026-07-15 at 12  26 29@2x" src="https://github.com/user-attachments/assets/b9bdfa13-c7a7-4a26-a514-c74132f1f38b" />

</td>
</tr>
</tbody>
</table>